### PR TITLE
Fix Insights blank page, add Species page links, fix Weather chart temperature line

### DIFF
--- a/homepage/views.php
+++ b/homepage/views.php
@@ -512,7 +512,7 @@ if(isset($_GET['view'])){
   if($_GET['view'] == "Kiosk"){$kiosk = true;include('todays_detections.php');}
   if($_GET['view'] == "Species Stats"){include('stats.php');}
   if($_GET['view'] == "Weekly Report" || $_GET['view'] == "Report" || $_GET['view'] == "Reports"){include('scripts/reports.php');}
-  if($_GET['view'] == "Insights"){include('insights.php');}
+  if($_GET['view'] == "Insights"){include('scripts/insights.php');}
   if($_GET['view'] == "Analytics"){include('scripts/analytics.php');}
   if($_GET['view'] == "Species"){include('scripts/species.php');}
   if($_GET['view'] == "Daily Charts"){include('history.php');}

--- a/scripts/insights.php
+++ b/scripts/insights.php
@@ -285,7 +285,7 @@ if ($subview == 'environmental') {
         $wind_impact = $unified_wind;
         $ideal_res = $db->query("SELECT d.Com_Name, ROUND(AVG(w.Temp), 1) as avg_temp, ROUND(MIN(w.Temp), 1) as min_temp, ROUND(MAX(w.Temp), 1) as max_temp, COUNT(*) as cnt FROM detections d INNER JOIN weather w ON d.Date = w.Date AND CAST(substr(d.Time, 1, 2) AS INTEGER) = w.Hour GROUP BY d.Sci_Name HAVING cnt >= 5 ORDER BY cnt DESC");
         while($row = $ideal_res->fetchArray(SQLITE3_ASSOC)) { $species_ideal[] = $row; }
-        $trend_res = $db->query("SELECT d.Date, COUNT(*) as det_count, ROUND(AVG(w.Temp), 1) as avg_temp FROM detections d LEFT JOIN weather w ON d.Date = w.Date AND CAST(substr(d.Time, 1, 2) AS INTEGER) = w.Hour WHERE d.Date >= '$one_month_ago' GROUP BY d.Date ORDER BY d.Date ASC");
+        $trend_res = $db->query("SELECT d.Date, COUNT(*) as det_count, ROUND((SELECT AVG(w2.Temp) FROM weather w2 WHERE w2.Date = d.Date), 1) as avg_temp FROM detections d WHERE d.Date >= '$one_month_ago' GROUP BY d.Date ORDER BY d.Date ASC");
         while($row = $trend_res->fetchArray(SQLITE3_ASSOC)) { $temp_vs_detections[] = $row; }
         $temp_trend_labels = json_encode(array_map(function($r) { return date('M j', strtotime($r['Date'])); }, $temp_vs_detections));
         $temp_trend_temps = json_encode(array_map(function($r) { return $r['avg_temp']; }, $temp_vs_detections));

--- a/scripts/species.php
+++ b/scripts/species.php
@@ -184,6 +184,10 @@ if ($image_provider && $image_provider->is_reset()) {
 .stats-table { width: 100%; font-size: 0.85rem; }
 .stats-table tr td:first-child { color: var(--text-muted); padding-bottom: 4px; }
 .stats-table tr td:last-child { text-align: right; font-weight: 600; color: var(--text-primary); padding-bottom: 4px; }
+.species-card-links { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 14px; }
+.species-card-links .mrd-link-pill { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border-radius: 20px; font-size: 0.78rem; font-weight: 600; text-decoration: none; color: var(--text-muted); background: var(--bg-input, #f1f5f9); border: 1px solid var(--border); transition: background 0.2s, color 0.2s; }
+.species-card-links .mrd-link-pill img { width: 12px; height: 12px; }
+.species-card-links .mrd-link-pill:hover { background: var(--accent); color: white; }
 
 </style>
 
@@ -304,6 +308,11 @@ if ($image_provider && $image_provider->is_reset()) {
                         <tr><td>Confidence:</td><td><?php echo round($bird['MaxConf'] * 100, 1); ?>%</td></tr>
                         <tr><td>First:</td><td><?php echo date('n/j/Y', strtotime($bird['FirstDate'])); ?></td></tr>
                     </table>
+                    <?php $info = get_info_url($sci_name); ?>
+                    <div class="species-card-links">
+                        <a href="<?php echo $info['URL']; ?>" target="_blank" class="mrd-link-pill"><img src="images/info.png"> <?php echo $info['TITLE']; ?></a>
+                        <a href="https://wikipedia.org/wiki/<?php echo urlencode($sci_name); ?>" target="_blank" class="mrd-link-pill"><img src="images/wiki.png"> Wikipedia</a>
+                    </div>
                 </div>
             </div>
         <?php endforeach; ?>


### PR DESCRIPTION
## Summary
Three bug fixes and one feature addition were found while running this fork on a Raspberry Pi 4B with RaspiOS Bookworm.

## Changes

### 1. Bug Fix — Insights page was completely blank (`homepage/views.php`)
`views.php` was calling `include('insights.php')` but the file lives at `scripts/insights.php`. All other views correctly use the `scripts/` prefix (Analytics, Species, etc.) — Insights was the only one missing it, causing PHP to silently include nothing and render a blank page. One-line fix.

### 2. Feature — All About Birds / Wikipedia links on Species page (`scripts/species.php`)
The Overview and Recordings pages both show quick-link pill buttons (Info + Wikipedia) per species detection, but the Species gallery page had no equivalent. Added the same `mrd-link-pill` buttons to each bird card using the existing `get_info_url()` function. Respects the database language setting (shows eBird link for non-English installs). CSS is scoped to `.species-card-links` so it doesn't affect any other views.

### 3. Bug Fix — Weather Insights temperature line showing gaps (`scripts/insights.php`)
The Temperature vs Detections trend chart was joining detections to weather on an exact hour-level match (`d.Date = w.Date AND CAST(substr(d.Time, 1, 2) AS INTEGER) = w.Hour`). Any detection hour without a matching weather row produced a NULL temperature, and since `AVG()` silently skips NULLs the line disappeared for most days. Replaced with a daily average subquery so any day with partial weather data still produces a valid temperature reading.

## Tested On
- Raspberry Pi 4B
- RaspiOS Bookworm (Debian 12)
- Migrated from Nachtzuster fork