### PR TITLE
Add configurable temperature unit (Celsius/Fahrenheit) 

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,6 +13,7 @@ install provides: the config file, the docroot link layout, and a database.
    BIRDNET_USER=pi
    SITE_NAME="BirdNET-Pi Dev"
    COLOR_SCHEME=light
+   TEMPERATURE_UNIT=fahrenheit
    LATITUDE=40.030
    LONGITUDE=-75.020
    SILENCE_UPDATE_INDICATOR=0

--- a/homepage/static/dashboard-charts.js
+++ b/homepage/static/dashboard-charts.js
@@ -139,7 +139,7 @@
                 ctx.fillText(emoji, x, yHour - 16);
                 ctx.font = '10px Roboto Flex, sans-serif';
                 ctx.fillStyle = isDark ? '#aaaaaa' : '#666666';
-                ctx.fillText(w.temp + '°', x, yHour - 28);
+                ctx.fillText(w.temp + '°F', x, yHour - 28);
             }
         });
 

--- a/homepage/static/dashboard-charts.js
+++ b/homepage/static/dashboard-charts.js
@@ -43,6 +43,7 @@
         var hourly = data.hourly;
         var currentHour = data.currentHour;
         var weather = data.weather;
+        var weatherUnit = data.weather_unit || 'F';
         var hasWeather = weather && Object.keys(weather).length > 0;
 
         var displayed = species;
@@ -139,7 +140,7 @@
                 ctx.fillText(emoji, x, yHour - 16);
                 ctx.font = '10px Roboto Flex, sans-serif';
                 ctx.fillStyle = isDark ? '#aaaaaa' : '#666666';
-                ctx.fillText(w.temp + '°F', x, yHour - 28);
+                ctx.fillText(w.temp + '°' + weatherUnit, x, yHour - 28);
             }
         });
 
@@ -261,6 +262,7 @@
             var species = lastData.species;
             var hourly = lastData.hourly;
             var weather = lastData.weather;
+            var weatherUnit = lastData.weather_unit || 'F';
             var hasWeather = weather && Object.keys(weather).length > 0;
 
             var rect = canvas.getBoundingClientRect();
@@ -317,7 +319,7 @@
                         95: 'Thunderstorm', 96: 'Thunderstorm with Hail', 99: 'Thunderstorm with Heavy Hail'
                     };
                     var cond = codes[w.code] || 'Cloudy';
-                    weatherStr = '<br><span style="color:#aaa;font-size:10px;">' + w.temp + '°F • ' + cond + '</span>';
+                    weatherStr = '<br><span style="color:#aaa;font-size:10px;">' + w.temp + '°' + weatherUnit + ' • ' + cond + '</span>';
                 }
                 tooltip.innerHTML = '<strong>' + name + '</strong><br>' + hour + ':00 — ' + val + ' detection' + (val !== 1 ? 's' : '') + weatherStr;
                 tooltip.style.display = 'block';

--- a/homepage/static/ui-helpers.js
+++ b/homepage/static/ui-helpers.js
@@ -95,7 +95,7 @@
         'Disk usage could not be read.';
       var lastDetection = health.last_detection_at || 'No detections';
       var weatherIsCurrent = weather.status === 'current';
-      var weatherLabel = weatherIsCurrent ? (Math.round(Number(weather.temp)) + '\u00b0F ' + (weather.condition || '')) : 'Missing current hour';
+      var weatherLabel = weatherIsCurrent ? (Math.round(Number(weather.temp)) + '\u00b0' + (weather.unit || 'F') + ' ' + (weather.condition || '')) : 'Missing current hour';
       var weatherTooltip = weatherIsCurrent ?
         'Current-hour weather from the weather sync table. This should match Live Activity. Synced row: ' + (weather.last_synced_at || 'unknown') + '.' :
         'Current-hour weather is missing. Last synced row: ' + (weather.last_synced_at || 'none') + '.';

--- a/homepage/views.php
+++ b/homepage/views.php
@@ -246,7 +246,7 @@ foreach ($main_nav as $nav_item) {
               $w_stmt->bindValue(1, (int)date('G'), SQLITE3_INTEGER);
               $w_res = db_execute_safe($feed_db, $w_stmt, 'sidebar current weather');
               if ($w_row = db_fetch_assoc_safe($w_res)) {
-                  $temp = round((float)$w_row['Temp']);
+                  $temp = display_temp($w_row['Temp']);
                   $code = (int)$w_row['ConditionCode'];
                   $is_day = $hasIsDay ? (int)$w_row['IsDay'] : 1;
                   
@@ -260,7 +260,8 @@ foreach ($main_nav as $nav_item) {
                   elseif ($code >= 80 && $code <= 82) $emoji = $is_day === 0 ? '🌧️' : '🌦️';
                   elseif ($code >= 95) $emoji = '⛈️';
                   
-                  $current_weather_str = "<span id='liveFeedWeather' style='margin-left:auto; font-size:0.9em; font-weight:normal; color:var(--text-secondary, #6b7280);'>{$temp}&deg;F {$emoji}</span>";
+                  $temp_unit_html = h(temp_unit_symbol());
+                  $current_weather_str = "<span id='liveFeedWeather' style='margin-left:auto; font-size:0.9em; font-weight:normal; color:var(--text-secondary, #6b7280);'>{$temp}&deg;{$temp_unit_html} {$emoji}</span>";
               }
           }
       }
@@ -298,7 +299,7 @@ foreach ($main_nav as $nav_item) {
         if (!data || data.status !== 'current') return;
         const weather = document.getElementById('liveFeedWeather');
         if (!weather) return;
-        weather.innerHTML = Math.round(Number(data.temp)) + '&deg;F ' + liveFeedWeatherEmoji(data.condition_code, data.is_day);
+        weather.innerHTML = Math.round(Number(data.temp)) + '&deg;' + (data.unit || 'F') + ' ' + liveFeedWeatherEmoji(data.condition_code, data.is_day);
       })
       .catch(() => {
         // Keep the last known weather visible during transient API or database failures.

--- a/scripts/api.php
+++ b/scripts/api.php
@@ -130,7 +130,8 @@ function api_current_weather($db) {
     'status' => 'current',
     'date' => $current['Date'],
     'hour' => (int)$current['Hour'],
-    'temp' => round((float)$current['Temp']),
+    'temp' => display_temp($current['Temp']),
+    'unit' => temp_unit_symbol(),
     'condition_code' => $code,
     'condition' => api_weather_label($code),
     'is_day' => $has_is_day ? (int)$current['IsDay'] : 1,
@@ -627,7 +628,7 @@ if (preg_match('#^/api/v1/system/health$#', $requestUri)) {
       $w_res = db_execute_safe($db, $w_stmt, 'timeline weather rows');
       while ($w_row = db_fetch_assoc_safe($w_res)) {
         $weather_map[(int)$w_row['Hour']] = [
-          'temp' => round((float)$w_row['Temp']),
+          'temp' => display_temp($w_row['Temp']),
           'code' => (int)$w_row['ConditionCode'],
           'is_day' => isset($w_row['IsDay']) ? (int)$w_row['IsDay'] : 1
         ];
@@ -643,7 +644,8 @@ if (preg_match('#^/api/v1/system/health$#', $requestUri)) {
     'total_species' => count($species_set),
     'peak_hour' => $peak_hour,
     'hours' => $hours_result,
-    'weather' => $weather_map
+    'weather' => $weather_map,
+    'weather_unit' => temp_unit_symbol()
   ]);
 
 } elseif (preg_match('#^/api/v1/species/search$#', $requestUri)) {

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -768,6 +768,28 @@ function get_visit_gap_seconds() {
   return (int)round($minutes * 60);
 }
 
+// Weather is always stored in the 'weather' table as Fahrenheit; this is the single
+// place that decides the display unit and converts for it.
+function get_temp_unit() {
+  $config = get_config();
+  return (isset($config['TEMPERATURE_UNIT']) && strtolower($config['TEMPERATURE_UNIT']) === 'celsius') ? 'C' : 'F';
+}
+
+function temp_unit_symbol() {
+  return get_temp_unit();
+}
+
+function display_temp($fahrenheit, $decimals = 0) {
+  if ($fahrenheit === null || $fahrenheit === '') {
+    return null;
+  }
+  $value = (float)$fahrenheit;
+  if (get_temp_unit() === 'C') {
+    $value = ($value - 32) * 5 / 9;
+  }
+  return round($value, $decimals);
+}
+
 /* $rows must be sorted by Date ASC, Time ASC and contain
    Date, Time, Sci_Name, Com_Name, Confidence, File_Name. */
 function visits_from_detections($rows, $gap_seconds = null) {

--- a/scripts/config.php
+++ b/scripts/config.php
@@ -71,6 +71,7 @@ if(isset($_GET["latitude"])){
   $language = $_GET["language"];
   $info_site = $_GET["info_site"];
   $color_scheme = $_GET["color_scheme"];
+  $temp_unit = (isset($_GET['temp_unit']) && strtolower($_GET['temp_unit']) === 'celsius') ? 'celsius' : 'fahrenheit';
   $timezone = $_GET["timezone"];
   $model = $_GET["model"];
   $sf_thresh = $_GET["sf_thresh"];
@@ -177,7 +178,12 @@ if(isset($_GET["latitude"])){
     $contents = preg_replace("/DATABASE_LANG=.*/", "DATABASE_LANG=$language", $contents);
   }
   $contents = preg_replace("/INFO_SITE=.*/", "INFO_SITE=$info_site", $contents);
-  $contents = preg_replace("/COLOR_SCHEME=.*/", "COLOR_SCHEME=$color_scheme", $contents);  
+  $contents = preg_replace("/COLOR_SCHEME=.*/", "COLOR_SCHEME=$color_scheme", $contents);
+  if (preg_match('/^TEMPERATURE_UNIT=.*/m', $contents)) {
+    $contents = preg_replace("/TEMPERATURE_UNIT=.*/", "TEMPERATURE_UNIT=$temp_unit", $contents);
+  } else {
+    $contents .= "\nTEMPERATURE_UNIT=$temp_unit\n";
+  }
   $contents = preg_replace("/FLICKR_FILTER_EMAIL=.*/", "FLICKR_FILTER_EMAIL=$flickr_filter_email", $contents);
   $contents = preg_replace("/APPRISE_MINIMUM_SECONDS_BETWEEN_NOTIFICATIONS_PER_SPECIES=.*/", "APPRISE_MINIMUM_SECONDS_BETWEEN_NOTIFICATIONS_PER_SPECIES=$minimum_time_limit", $contents);
   $contents = preg_replace("/MODEL=.*/", "MODEL=$model", $contents);
@@ -680,6 +686,22 @@ https://discordapp.com/api/webhooks/{WebhookID}/{WebhookToken}
           echo "<option value='{$color_scheme}' $isSelected>$color_scheme</option>";
         }
       ?>
+      </td></tr></table><br>
+
+      <table class="settingstable"><tr><td>
+      <h2>Temperature unit</h2>
+      Applies to weather readouts across the site (Now, Timeline, Overview, Insights).<br><br>
+      <label for="temp_unit">Show temperatures in : </label>
+      <select name="temp_unit" class="testbtn">
+      <?php
+      $temp_units = ['fahrenheit' => 'Fahrenheit (°F)', 'celsius' => 'Celsius (°C)'];
+      $current_temp_unit = (get_temp_unit() === 'C') ? 'celsius' : 'fahrenheit';
+      foreach($temp_units as $unit_value => $unit_label){
+          $isSelected = ($current_temp_unit === $unit_value) ? 'selected="selected"' : '';
+          echo "<option value='{$unit_value}' $isSelected>{$unit_label}</option>";
+        }
+      ?>
+      </select>
       </td></tr></table><br>
         
       <script>

--- a/scripts/insights.php
+++ b/scripts/insights.php
@@ -368,17 +368,20 @@ if ($subview == 'environmental') {
     $wmo_codes = [0 => 'Clear sky', 1 => 'Mostly clear', 2 => 'Partly cloudy', 3 => 'Overcast', 45 => 'Fog', 48 => 'Rime fog', 51 => 'Light drizzle', 53 => 'Moderate drizzle', 55 => 'Dense drizzle', 61 => 'Slight rain', 63 => 'Moderate rain', 65 => 'Heavy rain', 71 => 'Slight snow', 73 => 'Moderate snow', 75 => 'Heavy snow', 80 => 'Slight showers', 81 => 'Moderate showers', 82 => 'Violent showers', 95 => 'Thunderstorm', 96 => 'Thunderstorm + hail', 99 => 'Thunderstorm + heavy hail'];
     $has_weather = (db_query_single_safe($db, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='weather'", 0, 'insights weather table exists') > 0) && (db_query_single_safe($db, "SELECT COUNT(*) FROM weather", 0, 'insights weather row count') > 0);
     if ($has_weather) {
-        $temp_res = db_query_safe($db, "SELECT CASE WHEN w.Temp IS NULL THEN 'Unknown' WHEN w.Temp < 32 THEN 'Below 32°F' WHEN w.Temp < 46 THEN '32–45°F' WHEN w.Temp < 56 THEN '46–55°F' WHEN w.Temp < 66 THEN '56–65°F' WHEN w.Temp < 76 THEN '66–75°F' WHEN w.Temp < 86 THEN '76–85°F' WHEN w.Temp < 96 THEN '86–95°F' ELSE 'Above 95°F' END as bracket, COUNT(*) as det_count, COUNT(DISTINCT d.Sci_Name) as species_count, ROUND(AVG(w.Temp), 1) as avg_temp FROM detections d INNER JOIN weather w ON d.Date = w.Date AND CAST(substr(d.Time, 1, 2) AS INTEGER) = w.Hour GROUP BY bracket", 'insights weather temperature brackets');
-        $master_brackets = [
-            'Below 32°F' => ['bracket' => 'Below 32°F', 'det_count' => 0, 'species_count' => 0],
-            '32–45°F' => ['bracket' => '32–45°F', 'det_count' => 0, 'species_count' => 0],
-            '46–55°F' => ['bracket' => '46–55°F', 'det_count' => 0, 'species_count' => 0],
-            '56–65°F' => ['bracket' => '56–65°F', 'det_count' => 0, 'species_count' => 0],
-            '66–75°F' => ['bracket' => '66–75°F', 'det_count' => 0, 'species_count' => 0],
-            '76–85°F' => ['bracket' => '76–85°F', 'det_count' => 0, 'species_count' => 0],
-            '86–95°F' => ['bracket' => '86–95°F', 'det_count' => 0, 'species_count' => 0],
-            'Above 95°F' => ['bracket' => 'Above 95°F', 'det_count' => 0, 'species_count' => 0]
-        ];
+        // w.Temp is always stored in Fahrenheit; bucket boundaries below are chosen so each
+        // unit gets clean, natural-feeling bins (5°C steps map exactly to the °F thresholds).
+        if (get_temp_unit() === 'C') {
+            $temp_case_sql = "CASE WHEN w.Temp IS NULL THEN 'Unknown' WHEN w.Temp < 32 THEN 'Below 0°C' WHEN w.Temp < 41 THEN '0–4°C' WHEN w.Temp < 50 THEN '5–9°C' WHEN w.Temp < 59 THEN '10–14°C' WHEN w.Temp < 68 THEN '15–19°C' WHEN w.Temp < 77 THEN '20–24°C' WHEN w.Temp < 86 THEN '25–29°C' ELSE 'Above 29°C' END as bracket";
+            $bracket_labels = ['Below 0°C', '0–4°C', '5–9°C', '10–14°C', '15–19°C', '20–24°C', '25–29°C', 'Above 29°C'];
+        } else {
+            $temp_case_sql = "CASE WHEN w.Temp IS NULL THEN 'Unknown' WHEN w.Temp < 32 THEN 'Below 32°F' WHEN w.Temp < 46 THEN '32–45°F' WHEN w.Temp < 56 THEN '46–55°F' WHEN w.Temp < 66 THEN '56–65°F' WHEN w.Temp < 76 THEN '66–75°F' WHEN w.Temp < 86 THEN '76–85°F' WHEN w.Temp < 96 THEN '86–95°F' ELSE 'Above 95°F' END as bracket";
+            $bracket_labels = ['Below 32°F', '32–45°F', '46–55°F', '56–65°F', '66–75°F', '76–85°F', '86–95°F', 'Above 95°F'];
+        }
+        $temp_res = db_query_safe($db, "SELECT $temp_case_sql, COUNT(*) as det_count, COUNT(DISTINCT d.Sci_Name) as species_count, ROUND(AVG(w.Temp), 1) as avg_temp FROM detections d INNER JOIN weather w ON d.Date = w.Date AND CAST(substr(d.Time, 1, 2) AS INTEGER) = w.Hour GROUP BY bracket", 'insights weather temperature brackets');
+        $master_brackets = [];
+        foreach ($bracket_labels as $label) {
+            $master_brackets[$label] = ['bracket' => $label, 'det_count' => 0, 'species_count' => 0];
+        }
         while($row = db_fetch_assoc_safe($temp_res)) {
             if (isset($master_brackets[$row['bracket']])) {
                 $master_brackets[$row['bracket']] = $row;
@@ -493,7 +496,12 @@ if ($subview == 'environmental') {
         }
         $wind_impact = $unified_wind;
         $ideal_res = db_query_safe($db, "SELECT d.Com_Name, ROUND(AVG(w.Temp), 1) as avg_temp, ROUND(MIN(w.Temp), 1) as min_temp, ROUND(MAX(w.Temp), 1) as max_temp, COUNT(*) as cnt FROM detections d INNER JOIN weather w ON d.Date = w.Date AND CAST(substr(d.Time, 1, 2) AS INTEGER) = w.Hour GROUP BY d.Sci_Name HAVING cnt >= 5 ORDER BY cnt DESC", 'insights species ideal temperature');
-        while($row = db_fetch_assoc_safe($ideal_res)) { $species_ideal[] = $row; }
+        while($row = db_fetch_assoc_safe($ideal_res)) {
+            $row['avg_temp'] = display_temp($row['avg_temp'], 1);
+            $row['min_temp'] = display_temp($row['min_temp'], 1);
+            $row['max_temp'] = display_temp($row['max_temp'], 1);
+            $species_ideal[] = $row;
+        }
         $trend_stmt = $db->prepare("
             SELECT d.Date,
                    COUNT(*) as det_count,
@@ -514,7 +522,7 @@ if ($subview == 'environmental') {
         $trend_res = db_execute_safe($db, $trend_stmt, 'insights weather trend');
         while($row = db_fetch_assoc_safe($trend_res)) { $temp_vs_detections[] = $row; }
         $temp_trend_labels = json_encode(array_map(function($r) { return date('M j', strtotime($r['Date'])); }, $temp_vs_detections));
-        $temp_trend_temps = json_encode(array_map(function($r) { return $r['avg_temp']; }, $temp_vs_detections));
+        $temp_trend_temps = json_encode(array_map(function($r) { return display_temp($r['avg_temp'], 1); }, $temp_vs_detections));
         $temp_trend_dets = json_encode(array_map(function($r) { return $r['det_count']; }, $temp_vs_detections));
     }
 }
@@ -1474,9 +1482,9 @@ $db->close();
             <div class="insights-stats-item <?php echo $rank_temp > 10 ? 'hidden-item' : ''; ?>">
                 <div>
                     <div class="insights-stats-name" style="margin-bottom: 2px;"><?php echo $sp['Com_Name']; ?></div>
-                    <div style="font-size: 0.8em; color: var(--text-muted);">Range: <?php echo $sp['min_temp']; ?>°F – <?php echo $sp['max_temp']; ?>°F · <?php echo number_format($sp['cnt']); ?> detections</div>
+                    <div style="font-size: 0.8em; color: var(--text-muted);">Range: <?php echo $sp['min_temp']; ?>°<?php echo get_temp_unit(); ?> – <?php echo $sp['max_temp']; ?>°<?php echo get_temp_unit(); ?> · <?php echo number_format($sp['cnt']); ?> detections</div>
                 </div>
-                <span class="insights-stats-count">~<?php echo $sp['avg_temp']; ?>°F</span>
+                <span class="insights-stats-count">~<?php echo $sp['avg_temp']; ?>°<?php echo get_temp_unit(); ?></span>
             </div>
             <?php $rank_temp++; endforeach; ?>
             <?php endif; ?>
@@ -1866,7 +1874,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     borderWidth: 1,
                     yAxisID: 'y-dets'
                 }, {
-                    label: 'Avg Temp (°F)',
+                    label: 'Avg Temp (°<?php echo get_temp_unit(); ?>)',
                     type: 'line',
                     data: <?php echo $temp_trend_temps; ?>,
                     borderColor: '#f59e0b',
@@ -1883,7 +1891,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 scales: {
                     yAxes: [
                         { id: 'y-dets', position: 'left', ticks: { beginAtZero: true, fontColor: fontColor }, scaleLabel: { display: true, labelString: 'Detections', fontColor: fontColor } },
-                        { id: 'y-temp', position: 'right', ticks: { fontColor: '#f59e0b' }, scaleLabel: { display: true, labelString: 'Temp (°F)', fontColor: '#f59e0b' }, gridLines: { drawOnChartArea: false } }
+                        { id: 'y-temp', position: 'right', ticks: { fontColor: '#f59e0b' }, scaleLabel: { display: true, labelString: 'Temp (°<?php echo get_temp_unit(); ?>)', fontColor: '#f59e0b' }, gridLines: { drawOnChartArea: false } }
                     ],
                     xAxes: [{ ticks: { fontColor: fontColor, maxRotation: 45, minRotation: 0 } }]
                 }

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -141,6 +141,13 @@ INFO_SITE="ALLABOUTBIRDS"
 
 COLOR_SCHEME="light"
 
+#---------------------------  Weather Temperature Unit  ------------------------#
+## Unit used for displaying temperature in the web interface and weather data.
+## Valid values: fahrenheit or celsius
+## default fahrenheit
+
+TEMPERATURE_UNIT=fahrenheit
+
 #------------------------------  Disk Management  ------------------------------#
 ## FULL_DISK can be set to configure how the system reacts to a full disk
 ## purge = Remove the oldest day's worth of recordings

--- a/scripts/now.php
+++ b/scripts/now.php
@@ -283,7 +283,7 @@ $visit_explainer = 'A visit groups repeated detections of the same bird. After '
       : esc(formatAgo(v.seconds_ago));
     var weather = '';
     if (data.weather && data.weather.status === 'current') {
-      weather = ' &middot; ' + Math.round(data.weather.temp) + '&deg;F ' + esc(data.weather.condition);
+      weather = ' &middot; ' + Math.round(data.weather.temp) + '&deg;' + (data.weather.unit || 'F') + ' ' + esc(data.weather.condition);
     }
     document.getElementById('heroMeta').innerHTML =
       when +
@@ -348,7 +348,7 @@ $visit_explainer = 'A visit groups repeated detections of the same bird. After '
     return (h - 12) + 'p';
   }
 
-  function renderHourChart(hourly, weather, currentHour) {
+  function renderHourChart(hourly, weather, currentHour, weatherUnit) {
     var max = 1;
     var counts = [];
     for (var h = 0; h < 24; h++) {
@@ -371,7 +371,7 @@ $visit_explainer = 'A visit groups repeated detections of the same bird. After '
       axis += '<div class="axis-col">' +
         '<span class="axis-time">' + hourLabel(ah) + '</span>' +
         (w ? '<span class="axis-weather" aria-hidden="true">' + weatherEmoji(w.code, w.is_day) + '</span>' +
-             '<span class="axis-temp">' + Math.round(w.temp) + '&deg;F</span>' : '') +
+             '<span class="axis-temp">' + Math.round(w.temp) + '&deg;' + (weatherUnit || 'F') + '</span>' : '') +
         '</div>';
     }
     return '<div class="spark">' + bars + '</div><div class="spark-axis">' + axis + '</div>';
@@ -392,7 +392,7 @@ $visit_explainer = 'A visit groups repeated detections of the same bird. After '
           '<a class="species-card-name" href="' + detailHref + '" title="' + esc(s.name) + '">' + esc(s.name) + '</a>' +
           '<span class="species-card-stats">' + s.count + ' detection' + (s.count === 1 ? '' : 's') + '</span>' +
         '</div>' +
-        renderHourChart(data.hourly ? data.hourly[s.name] : null, data.weather, data.currentHour) +
+        renderHourChart(data.hourly ? data.hourly[s.name] : null, data.weather, data.currentHour, data.weather_unit) +
         '</div>';
     }).join('');
   }

--- a/scripts/now.php
+++ b/scripts/now.php
@@ -371,7 +371,7 @@ $visit_explainer = 'A visit groups repeated detections of the same bird. After '
       axis += '<div class="axis-col">' +
         '<span class="axis-time">' + hourLabel(ah) + '</span>' +
         (w ? '<span class="axis-weather" aria-hidden="true">' + weatherEmoji(w.code, w.is_day) + '</span>' +
-             '<span class="axis-temp">' + Math.round(w.temp) + '&deg;</span>' : '') +
+             '<span class="axis-temp">' + Math.round(w.temp) + '&deg;F</span>' : '') +
         '</div>';
     }
     return '<div class="spark">' + bars + '</div><div class="spark-axis">' + axis + '</div>';

--- a/scripts/overview.php
+++ b/scripts/overview.php
@@ -46,7 +46,7 @@ function get_overview_weather($db, $date) {
 
   while ($row = db_fetch_assoc_safe($res)) {
     $weather[(int)$row['Hour']] = [
-      'temp' => round((float)$row['Temp']),
+      'temp' => display_temp($row['Temp']),
       'code' => (int)$row['ConditionCode'],
       'is_day' => $hasIsDay ? (int)$row['IsDay'] : 1
     ];
@@ -192,7 +192,7 @@ if(isset($_GET['ajax_chart_data']) && $_GET['ajax_chart_data'] == "true") {
       $weather = get_overview_weather($db, $today);
   }
 
-  echo json_encode(['species' => $species, 'hourly' => $hourly, 'weather' => $weather, 'currentHour' => $currentHour]);
+  echo json_encode(['species' => $species, 'hourly' => $hourly, 'weather' => $weather, 'weather_unit' => temp_unit_symbol(), 'currentHour' => $currentHour]);
   die();
 }
 

--- a/scripts/timeline.php
+++ b/scripts/timeline.php
@@ -113,7 +113,7 @@ $tl_date = isset($_GET['date']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $_GET['da
     for (var h = 0; h < 24; h++) {
       var w = data.weather ? data.weather[h] : null;
       weatherHtml += '<div class="tl-wcell">' + (w
-        ? '<span class="hm-weather" aria-hidden="true">' + weatherEmoji(w.code, w.is_day) + '</span><span class="hm-temp">' + w.temp + '&deg;F</span>'
+        ? '<span class="hm-weather" aria-hidden="true">' + weatherEmoji(w.code, w.is_day) + '</span><span class="hm-temp">' + w.temp + '&deg;' + (data.weather_unit || 'F') + '</span>'
         : '') + '</div>';
       hoursHtml += '<div class="tl-hcell">' + hourLabel(h) + '</div>';
     }

--- a/scripts/timeline.php
+++ b/scripts/timeline.php
@@ -113,7 +113,7 @@ $tl_date = isset($_GET['date']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $_GET['da
     for (var h = 0; h < 24; h++) {
       var w = data.weather ? data.weather[h] : null;
       weatherHtml += '<div class="tl-wcell">' + (w
-        ? '<span class="hm-weather" aria-hidden="true">' + weatherEmoji(w.code, w.is_day) + '</span><span class="hm-temp">' + w.temp + '&deg;</span>'
+        ? '<span class="hm-weather" aria-hidden="true">' + weatherEmoji(w.code, w.is_day) + '</span><span class="hm-temp">' + w.temp + '&deg;F</span>'
         : '') + '</div>';
       hoursHtml += '<div class="tl-hcell">' + hourLabel(h) + '</div>';
     }

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -331,6 +331,9 @@ fi
 if ! grep -E '^VISIT_GAP_MINUTES=' /etc/birdnet/birdnet.conf &>/dev/null;then
   echo "VISIT_GAP_MINUTES=5" >> /etc/birdnet/birdnet.conf
 fi
+if ! grep -E '^TEMPERATURE_UNIT=' /etc/birdnet/birdnet.conf &>/dev/null;then
+  echo "TEMPERATURE_UNIT=fahrenheit" >> /etc/birdnet/birdnet.conf
+fi
 
 # Data spine tables (Phase 1): reviews, species prefs, notes. Additive only -
 # the detections table is never altered. Keep in sync with createdb.sh and


### PR DESCRIPTION
## Summary
BirdNET-Pi has always shown temperature only in Fahrenheit. This adds a
`TEMPERATURE_UNIT` setting (`fahrenheit`/`celsius`, default `fahrenheit`)
with a dropdown on the Settings page, and makes every weather readout
respect it.

## Design
Weather stays stored in Fahrenheit in the DB — only the read path
converts, via helpers in `common.php` (`get_temp_unit()`,
`display_temp()`). This keeps a unit switch fully reversible: historical
averages/brackets never mix F and C values, which is exactly what would
happen if the raw value were stored in the currently-selected unit.

## Coverage
Now (hero + hourly axis), Timeline weather strip, Overview
heatmap/tooltip, sidebar live weather, System Health tile, and Insights
(temperature brackets, per-species avg/min/max, trend chart labels).
Insights gets proper 5°C bins in Celsius mode, not just relabeled °F
ranges — the edges (32/41/50/59/68/77/86°F) map exactly to 0/5/…/30°C.

## Backward compatibility
New installs default to `fahrenheit`; existing installs get the key
added on update, so no dashboard changes unless the user opts in.

## Test plan
- `php -l`, `bash -n`, and `node --check` pass on all changed files
- Verified °F→°C bracket edges land on exact 5°C steps
