### PR TITLE
Fatal error on Insights-Weather dashboard on fresh install and no detections

### DIFF
--- a/scripts/insights.php
+++ b/scripts/insights.php
@@ -532,6 +532,7 @@ if ($subview == 'environmental') {
         ensure_db_ok($trend_stmt);
         $trend_stmt->bindValue(':one_month_ago', $one_month_ago, SQLITE3_TEXT);
         $trend_res = db_execute_safe($db, $trend_stmt, 'insights weather trend');
+        $temp_vs_detections = [];
         while($row = db_fetch_assoc_safe($trend_res)) { $temp_vs_detections[] = $row; }
         $temp_trend_labels = json_encode(array_map(function($r) { return date('M j', strtotime($r['Date'])); }, $temp_vs_detections));
         $temp_trend_temps = json_encode(array_map(function($r) { return $r['avg_temp'] === null ? null : display_temp($r['avg_temp'], 1); }, $temp_vs_detections));


### PR DESCRIPTION
Corrected a fatal error on the Insights-Weather page when no detections had occurred on a fresh installation. By adding in the array initialization, the dashboard will load even without any detections. 

Fatal error: Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given in ~/BirdNET-Pi/scripts/insights.php:536 Stack trace: #0 ~/BirdNET-Pi/scripts/insights.php(536): array_map() #1 ~/BirdNET-Pi/homepage/views.php(472): include('...') #2 ~/BirdNET-Pi/homepage/index.php(12): include('...') #3 {main} thrown in ~/BirdNET-Pi/scripts/insights.php on line 536